### PR TITLE
Use normal read-syntax for embedded elisp code

### DIFF
--- a/clojure-mode/ns
+++ b/clojure-mode/ns
@@ -4,4 +4,4 @@
 (ns ^{:doc "$1"
       :author "`user-full-name`"}
   `(subst-char-in-string ?/ ?.
-    (subst-char-in-string ?_ ?-    (replace-regexp-in-string ".*?\\\\(?:\\\\test\\\\|src\\\\)/\\\\(.*\\\\).clj" "\\\\1" (buffer-file-name)))))`)
+    (subst-char-in-string ?_ ?-    (replace-regexp-in-string ".*?\\(?:\\test\\|src\\)/\\(.*\\).clj" "\\1" (buffer-file-name)))))`)


### PR DESCRIPTION
Instead of double-quoting all blackslashes. The current snippet did
not work for me.

I wonder how this snippet worked previously. I wan't able to find a commit message in yasnippets releated to reading embedded elisp code. 
